### PR TITLE
Feat: add Speechmatics STT provide

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -9,6 +9,10 @@
 # Speech-to-Text (STT) Providers - At least one required
 # ----------------------------------------------------------------------------
 
+# Speechmatics
+# https://portal.speechmatics.com
+# SPEECHMATICS_API_KEY=your_speechmatics_api_key_here
+
 # AssemblyAI
 # https://www.assemblyai.com
 # ASSEMBLYAI_API_KEY=your_assemblyai_api_key_here

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     assemblyai_api_key: str | None = Field(None, description="AssemblyAI API key for STT")
     cartesia_api_key: str | None = Field(None, description="Cartesia API key for STT")
     deepgram_api_key: str | None = Field(None, description="Deepgram API key for STT")
+    speechmatics_api_key: str | None = Field(None, description="Speechmatics API key for STT")
     aws_access_key_id: str | None = Field(None, description="AWS access key ID for Transcribe")
     aws_secret_access_key: str | None = Field(
         None, description="AWS secret access key for Transcribe"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -7,7 +7,7 @@ license = "AGPL-3.0-only"
 readme = "../README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pipecat-ai[anthropic,assemblyai,aws,azure,cartesia,cerebras,deepgram,google,groq,openai,openrouter,silero,webrtc,whisper]>=0.0.98",
+    "pipecat-ai[anthropic,speechmatics,assemblyai,aws,azure,cartesia,cerebras,deepgram,google,groq,openai,openrouter,silero,webrtc,whisper]>=0.0.98",
     "pydantic-settings>=2.12.0",
     "loguru>=0.7.3",
     "typer>=0.20.1",

--- a/server/services/provider_registry.py
+++ b/server/services/provider_registry.py
@@ -27,6 +27,7 @@ from pipecat.services.ollama.llm import OLLamaLLMService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.openai.stt import OpenAISTTService
 from pipecat.services.openrouter.llm import OpenRouterLLMService
+from pipecat.services.speechmatics.stt import SpeechmaticsSTTService
 from pipecat.services.stt_service import STTService
 from pipecat.services.whisper.stt import WhisperSTTService
 
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
 class STTProviderId(StrEnum):
     """Speech-to-Text provider identifiers."""
 
+    SPEECHMATICS = "speechmatics"
     ASSEMBLYAI = "assemblyai"
     AWS = "aws"
     AZURE = "azure"
@@ -219,6 +221,17 @@ class LLMProviderConfig:
 # =============================================================================
 
 STT_PROVIDERS: Final[dict[STTProviderId, STTProviderConfig]] = {
+    STTProviderId.SPEECHMATICS: STTProviderConfig(
+        provider_id=STTProviderId.SPEECHMATICS,
+        display_name="Speechmatics",
+        service_class=SpeechmaticsSTTService,
+        credential_mapper=ApiKeyMapper("speechmatics_api_key"),
+        default_kwargs={
+            "params": SpeechmaticsSTTService.InputParams(
+                end_of_utterance_silence_trigger=0.5,
+            )
+        },
+    ),
     STTProviderId.ASSEMBLYAI: STTProviderConfig(
         provider_id=STTProviderId.ASSEMBLYAI,
         display_name="AssemblyAI",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1632,6 +1632,9 @@ openai = [
 silero = [
     { name = "onnxruntime" },
 ]
+speechmatics = [
+    { name = "speechmatics-rt" },
+]
 webrtc = [
     { name = "aiortc" },
     { name = "opencv-python" },
@@ -2275,6 +2278,18 @@ wheels = [
 ]
 
 [[package]]
+name = "speechmatics-rt"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/a3/bb4d063a4405744951066c45ffbf7cd714a6fc00a20ef0cc83fe2494ed79/speechmatics_rt-0.5.3.tar.gz", hash = "sha256:c98d21041e5a0c90a66e463c3d5b98879c17eac0bbebb4100fd9d0f2b330bb19", size = 27333, upload-time = "2025-12-16T19:20:50.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/5a/35dd924f9bfeb1604e01806ad0e16a9c596f3c44d13e66794f10d10f828b/speechmatics_rt-0.5.3-py3-none-any.whl", hash = "sha256:12f97f19bb989852b8ff3c6d1e28f4f0ea6fd9356e19da75d0e9877545931ce6", size = 33365, upload-time = "2025-12-16T19:20:49.031Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2305,7 +2320,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "loguru" },
-    { name = "pipecat-ai", extra = ["anthropic", "assemblyai", "aws", "azure", "cartesia", "deepgram", "google", "groq", "openai", "silero", "webrtc", "whisper"] },
+    { name = "pipecat-ai", extra = ["anthropic", "assemblyai", "aws", "azure", "cartesia", "deepgram", "google", "groq", "openai", "silero", "speechmatics", "webrtc", "whisper"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "typer" },
@@ -2324,7 +2339,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.127.0" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "pipecat-ai", extras = ["anthropic", "assemblyai", "aws", "azure", "cartesia", "cerebras", "deepgram", "google", "groq", "openai", "openrouter", "silero", "webrtc", "whisper"], specifier = ">=0.0.98" },
+    { name = "pipecat-ai", extras = ["anthropic", "speechmatics", "assemblyai", "aws", "azure", "cartesia", "cerebras", "deepgram", "google", "groq", "openai", "openrouter", "silero", "webrtc", "whisper"], specifier = ">=0.0.98" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "typer", specifier = ">=0.20.1" },


### PR DESCRIPTION
Description:
  ## Summary
  - Add Speechmatics as an STT provider option
  - Uses `end_of_utterance_silence_trigger=0.5` for faster end-of-speech detection

 ## Changes
  - Added `SpeechmaticsSTTService` import and registry entry in `provider_registry.py`
  - Added `speechmatics_api_key` to Settings
  - Added `speechmatics` extra to pipecat-ai dependencies
  - Updated `.env.example` with Speechmatics configuration
  
 ## Notes
  Once pipecat-ai 0.0.99 is released, this can be upgraded to use `TurnDetectionMode.ADAPTIVE` for even better end-of-speech detection (server-side, no client VAD needed).

  ## Testing
  Tested locally with Speechmatics API key - transcription works correctly in the pipeline.