### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ name: CI
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   app-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kstonekuan/tambourine-voice/security/code-scanning/2](https://github.com/kstonekuan/tambourine-voice/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions` for the workflow or for each job, limiting the `GITHUB_TOKEN` to the minimal access required. Since the jobs here only read the repository and run checks, `contents: read` is sufficient.

The best fix without changing existing functionality is to add a `permissions` block at the workflow root (top level), so it applies to all jobs unless they override it. Place it after the `on:` block and before `jobs:` and set `contents: read`. None of the existing steps need write access, so this will not break them.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the trigger section (`"on": ...`) and the `jobs:` key. No additional imports or methods are needed; this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
