### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 
 "on":
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kstonekuan/tambourine-voice/security/code-scanning/1](https://github.com/kstonekuan/tambourine-voice/security/code-scanning/1)

In general, the problem is fixed by explicitly defining a `permissions:` block either at the workflow root (to apply to all jobs by default) or per job, granting only the scopes actually needed. For pure CI that only checks out code and runs tests, `contents: read` is usually sufficient.

For this workflow, the simplest, non‑breaking fix is to add a root-level `permissions:` block directly under the `name: CI` line. None of the jobs require write access to the repository or to issues/PRs; they only read the code and run commands. Therefore we can set `permissions: contents: read` at the top level so both `app-checks` and `server-checks` inherit these restricted permissions. No other lines or steps need to change.

Specifically, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: CI` line and the `"on":` block. No new imports or methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
