### PR TITLE
Docs: update README with Python version and complete provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Open-source alternative to [Wispr Flow](https://wisprflow.ai), [Superwhisper](ht
 **Why not proprietary tools?** Unlike Wispr Flow or Superwhisper, this project gives you full control and transparency.
 
 **Fully customizable.** This is your voice interface, built your way:
-- **Choose your AI providers** — Pick your STT (Cartesia, Deepgram, AssemblyAI) and LLM (Cerebras, OpenAI, Anthropic), run fully local with Whisper and Ollama, or use any of [Pipecat's supported services](https://docs.pipecat.ai/server/services/supported-services)
+- **Choose your AI providers** — Pick your STT (Cartesia, Deepgram, AssemblyAI, Speechmatics, Azure, AWS, Google, Groq, OpenAI) and LLM (Cerebras, OpenAI, Anthropic, Gemini, Groq, OpenRouter), run fully local with Whisper and Ollama, or add more from [Pipecat's supported services](https://docs.pipecat.ai/server/services/supported-services)
 - **Customize the formatting** — Modify prompts, add custom rules, build your personal dictionary
 - **Extend freely** — Built on [Pipecat](https://github.com/pipecat-ai/pipecat)'s modular pipeline, fully open-source
 
@@ -112,7 +112,7 @@ Open-source alternative to [Wispr Flow](https://wisprflow.ai), [Superwhisper](ht
 - Rust
 - Node.js
 - pnpm
-- Python
+- Python 3.13+
 - uv (Python package manager)
 
 ### Linux Dependencies


### PR DESCRIPTION
## Summary

- Add Python 3.13+ version requirement to Prerequisites section (enforced by `pyproject.toml`)
- Expand STT provider list to include all available providers: Speechmatics, Azure, AWS, Google, Groq, OpenAI
- Expand LLM provider list to include: Gemini, Groq, OpenRouter
- Change "use any of" to "add more from" for Pipecat services link (more accurate wording)

## Why these changes?

1. **Python version**: `pyproject.toml` enforces `requires-python = ">=3.13"` but README didn't mention this, causing confusion for new users
2. **Provider list**: README listed only 6 providers but code has 18 available in `server/services/provider_registry.py`

## Verification

- Verified Python 3.13+ requirement against `server/pyproject.toml:8`
- Verified provider list against `server/services/provider_registry.py` (STT_PROVIDERS and LLM_PROVIDERS)
- Node.js version intentionally left unspecified (not enforced in package.json)

Closes #72