### PR TITLE
Feat: relocate app version to settings

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -115,7 +115,6 @@ function Sidebar({
 
 			<footer className="sidebar-footer">
 				<ConnectionStatusIndicator />
-				<p className="sidebar-footer-text">v0.1.0</p>
 			</footer>
 		</aside>
 	);

--- a/app/src/components/settings/DataManagementSettings.tsx
+++ b/app/src/components/settings/DataManagementSettings.tsx
@@ -193,6 +193,17 @@ export function DataManagementSettings() {
 				</div>
 			</div>
 
+			{/* Version info */}
+			<Text
+				size="xs"
+				c="dimmed"
+				ta="center"
+				mt="xl"
+				className="animate-in animate-in-delay-5"
+			>
+				v0.1.0
+			</Text>
+
 			{/* History Import Strategy Modal */}
 			<Modal
 				opened={importModalState.type === "strategy"}


### PR DESCRIPTION
## Summary
Moves the app version number out of the sidebar footer and into the Data Management settings page, where it’s less distracting for most users.

## Changes
- Removed version display from the sidebar footer
- Added version information to the bottom of Data Management settings

## Motivation
The version number is not relevant for most users in the main UI and is better placed in a secondary location.

Closes #75
