### PR TITLE
feat: Add aria-label to microphone device selector

### DIFF
--- a/app/src/components/DeviceSelector.tsx
+++ b/app/src/components/DeviceSelector.tsx
@@ -90,6 +90,7 @@ export function DeviceSelector() {
 				onChange={handleChange}
 				allowDeselect={false}
 				className="device-selector"
+				aria-label="Select microphone device"
 			/>
 		</div>
 	);


### PR DESCRIPTION
#99 

Added aria-label="Select microphone device" to the microphone device selector dropdown in DeviceSelector.tsx to improve accessibility for screen reader users. This provides clear context about the dropdown's purpose for voice dictation.