### PR TITLE
Enable dictionary by default

### DIFF
--- a/app/src-tauri/src/settings.rs
+++ b/app/src-tauri/src/settings.rs
@@ -218,7 +218,7 @@ impl Default for CleanupPromptSections {
                 prompt_mode: PromptMode::Auto,
             },
             dictionary: PromptSection {
-                enabled: false,
+                enabled: true,
                 prompt_mode: PromptMode::Auto,
             },
         }

--- a/app/src/components/settings/PromptSettings.tsx
+++ b/app/src/components/settings/PromptSettings.tsx
@@ -13,7 +13,7 @@ import type { MutationStatus } from "./StatusIndicator";
 const DEFAULT_SECTIONS: CleanupPromptSections = {
 	main: { enabled: true, mode: { mode: "auto" } },
 	advanced: { enabled: true, mode: { mode: "auto" } },
-	dictionary: { enabled: false, mode: { mode: "auto" } },
+	dictionary: { enabled: true, mode: { mode: "auto" } },
 };
 
 type SectionKey = "main" | "advanced" | "dictionary";

--- a/server/processors/context_manager.py
+++ b/server/processors/context_manager.py
@@ -49,7 +49,7 @@ class DictationContextManager:
         self._main_custom: str | None = None
         self._advanced_enabled: bool = True
         self._advanced_custom: str | None = None
-        self._dictionary_enabled: bool = False
+        self._dictionary_enabled: bool = True
         self._dictionary_custom: str | None = None
 
         # Create shared context (will be reset before each recording)


### PR DESCRIPTION
## What

Enable dictionary setting by default in rust-backend/frontend/server and resolves https://github.com/kstonekuan/tambourine-voice/issues/77

## Testing

CI tests