### PR TITLE
Add GitHub Action to welcome first-time PR contributors

### DIFF
--- a/.github/workflows/welcome-first-time-contributors.yml
+++ b/.github/workflows/welcome-first-time-contributors.yml
@@ -1,0 +1,63 @@
+name: Welcome First-Time Contributors
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  thank_first_time_contributors:
+    name: Thank first-time contributors
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      (
+        github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+        github.event.pull_request.author_association == 'FIRST_TIMER'
+      )
+    steps:
+      - name: Comment on pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const thankYouMessage = [
+              `👋 Hi @${context.payload.pull_request.user.login} — thank you so much for your first contribution to Tambourine Voice!`,
+              '',
+              'If you have a minute, we would really appreciate your support:',
+              '- ⭐ Star the repo: https://github.com/kstonekuan/tambourine-voice',
+              '- 💬 Join our Discord: https://discord.gg/dUyuXWVJ2a',
+              '- 📣 Share the project with your network',
+              '',
+              'We are excited to have you here and appreciate your help making the project better! 🙌',
+            ].join('\n');
+
+            const markerText = '<!-- first-time-contributor-welcome -->';
+            const issueNumber = context.issue.number;
+
+            const { data: existingComments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const hasExistingWelcomeComment = existingComments.some((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(markerText),
+            );
+
+            if (hasExistingWelcomeComment) {
+              core.info('Welcome comment already exists. Skipping duplicate comment.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: `${markerText}\n${thankYouMessage}`,
+            });


### PR DESCRIPTION
### Motivation

- Provide a friendly automated thank-you to first-time contributors and encourage support actions (star the repo, join Discord, share the project). 
- Avoid posting duplicate messages and limit action scope to the minimum required permissions for commenting.

### Description

- Add a new workflow at `/.github/workflows/welcome-first-time-contributors.yml` that runs on `pull_request_target` for `opened` and `reopened` events. 
- The job runs only for human authors with `author_association` of `FIRST_TIME_CONTRIBUTOR` or `FIRST_TIMER` and skips bot authors. 
- The job uses `actions/github-script@v7` to post a hidden-marker-prefixed welcome comment that includes links to star the repo, join the Discord, and share the project, and it checks existing comments to prevent duplicates. 
- The workflow requests minimal write permissions (`issues: write` and `pull-requests: write`) needed to create comments.

### Testing

- Ran `git diff --check`, which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984eae80cc083339019fa9455720e8e)