### PR TITLE
Refactor: extract ky timeout and retry values into named constants

### DIFF
--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -780,13 +780,16 @@ export interface AvailableProvidersData {
 	llm: ProviderInfo[];
 }
 
+const API_RETRY_LIMIT= 2;
+const API_TIMEOUT_MS =10000;
+
 // Create ky instance with sensible defaults for API calls
 function createApiClient(serverUrl: string) {
 	return ky.create({
 		prefixUrl: withoutTrailingSlash(serverUrl),
-		timeout: 10000,
+		timeout: API_TIMEOUT_MS,
 		retry: {
-			limit: 2,
+			limit: API_RETRY_LIMIT,
 			methods: ["get", "post"],
 		},
 	});


### PR DESCRIPTION
Specifically:
- Extracted `timeout: 10000` into a named constant `API_TIMEOUT_MS`
- Extracted `retry: { limit: 2 }` into a named constant `API_RETRY_LIMIT`

Closes #96 