### PR TITLE
refactor: reuse ConnectionState from tauri

### DIFF
--- a/app/src/stores/recordingStore.ts
+++ b/app/src/stores/recordingStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { ConnectionState } from "../lib/tauri";
 
 /**
  * Simple UI state store for connection status display.
@@ -9,14 +10,6 @@ import { create } from "zustand";
  * The actual connection logic is managed by the XState machine in the overlay window.
  * This store just mirrors that state for UI display purposes.
  */
-type ConnectionState =
-	| "disconnected"
-	| "connecting"
-	| "reconnecting"
-	| "idle"
-	| "recording"
-	| "processing";
-
 interface RecordingState {
 	state: ConnectionState;
 	setState: (state: ConnectionState) => void;


### PR DESCRIPTION
## Summary
- remove the duplicated ConnectionState union in recordingStore.ts
- import the canonical ConnectionState type re-exported from lib/tauri

## Rationale
Issue #134 asks to reuse the central ConnectionState definition instead of maintaining a duplicate.

## Changes
- recordingStore now imports ConnectionState from ../lib/tauri and no longer defines it locally

## Test Plan
- CI passing on fork

Fixes #134