### PR TITLE
Refactor: extract connection delay constants for easier tuning

### DIFF
--- a/app/src/machines/connectionMachine.ts
+++ b/app/src/machines/connectionMachine.ts
@@ -25,6 +25,11 @@ import {
 	toSTTProviderSelection,
 } from "../lib/tauri";
 
+// Connection timing constants
+const CONNECTION_TIMEOUT_MS = 30000;
+const INITIAL_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 30000;
+
 /**
  * Clears the transport's keepAliveInterval to prevent "InvalidStateError" spam.
  * The library's stop() has a bug where the interval isn't cleared on abrupt disconnects.
@@ -502,10 +507,13 @@ export const connectionMachine = setup({
 		},
 	},
 	delays: {
-		connectionTimeout: 30000,
+		connectionTimeout: CONNECTION_TIMEOUT_MS,
 		// Exponential backoff: 1s, 2s, 4s, 8s... capped at 30s
 		retryDelay: ({ context }) =>
-			Math.min(1000 * 2 ** context.retryCount, 30000),
+			Math.min(
+				INITIAL_RETRY_DELAY_MS * 2 ** context.retryCount,
+				MAX_RETRY_DELAY_MS,
+			),
 	},
 }).createMachine({
 	id: "connection",


### PR DESCRIPTION
## Description

Extracts hardcoded connection timeout and retry delay values to named constants at the top of the file, improving readability and making them easier to tune.

## Changes

- Added `CONNECTION_TIMEOUT_MS` (30000ms)
- Added `INITIAL_RETRY_DELAY_MS` (1000ms)
- Added `MAX_RETRY_DELAY_MS` (30000ms)
- Updated `delays` config to use these constants

## Before

```typescript
delays: {
  connectionTimeout: 30000,
  retryDelay: ({ context }) =>
    Math.min(1000 * 2 ** context.retryCount, 30000),
}
```

## After

```typescript
// Connection timing constants
const CONNECTION_TIMEOUT_MS = 30000;
const INITIAL_RETRY_DELAY_MS = 1000;
const MAX_RETRY_DELAY_MS = 30000;

// ...

delays: {
  connectionTimeout: CONNECTION_TIMEOUT_MS,
  retryDelay: ({ context }) =>
    Math.min(
      INITIAL_RETRY_DELAY_MS * 2 ** context.retryCount,
      MAX_RETRY_DELAY_MS,
    ),
}
```
Closes #105
