### PR TITLE
Chore: remove .vscode from version control

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "rust-analyzer.linkedProjects": [
-    "app/src-tauri/Cargo.toml"
-  ],
-  "rust-analyzer.cargo.buildScripts.enable": true,
-  "rust-analyzer.procMacro.enable": true
-}


### PR DESCRIPTION
The `.vscode/` folder was being tracked by Git despite being listed in `.gitignore`, causing user-specific VS Code settings to be committed accidentally.

Changes:
- Removed `.vscode/settings.json` from version control using `git rm --cached`
- Local `.vscode/` folder remains intact for contributors' personal editor settings
- Prevents future accidental commits of IDE-specific configuration

Fixes the inconsistency between `.gitignore` rules and actual Git tracking.