### PR TITLE
fix(tauri): enforce single-instance startup to prevent duplicate launches

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4559,6 +4559,7 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-os",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-utils",
  "tempfile",
@@ -4885,6 +4886,21 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ rodio = { version = "0.21.1", default-features = false, features = [
 
 # Native audio capture (cross-platform: CoreAudio on macOS, WASAPI on Windows)
 cpal = "0.17.1"
+tauri-plugin-single-instance = "2.4.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2.3.1"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -441,6 +441,13 @@ pub fn run() {
 
     #[cfg(desktop)]
     {
+        builder = builder.plugin(tauri_plugin_single_instance::init(
+            |_app, _argv, _cwd| {
+                // Intentionally avoid showing/focusing windows on duplicate launch.
+                // The second process should terminate without side effects.
+                log::warn!("Ignoring duplicate app launch; primary instance remains active");
+            },
+        ));
         builder = builder.plugin(build_global_shortcut_plugin());
     }
 


### PR DESCRIPTION
## Summary

- Added a Tauri single-instance guard to prevent secondary app launches from initializing.
- Integrated `tauri-plugin-single-instance` in desktop startup flow.
- Updated duplicate-launch behavior to log and exit without opening/focusing windows, avoiding zombie/portal side effects during failed duplicate starts.

## Why this change

Launching the app from multiple terminals could start a second process far enough to create window/hotkey side effects before failing, leaving a “zombie” portal behavior. This ensures only the primary instance handles app lifecycle and UI startup.

## What was changed

- Added dependency: `tauri-plugin-single-instance` in `app/src-tauri/Cargo.toml`
- Registered plugin in `app/src-tauri/src/lib.rs` during desktop builder setup
- Duplicate-instance callback now intentionally avoids any window open/focus action and only logs a warning
- Lockfile updated accordingly (`app/src-tauri/Cargo.lock`)

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml` passes
- No lints introduced in modified Rust file
- Expected behavior: second launch exits cleanly and does not open Tambourine windows

Closes #151