### PR TITLE
Refactor: mark unused request parameter in get_default_sections

### DIFF
--- a/server/api/config_api.py
+++ b/server/api/config_api.py
@@ -190,12 +190,11 @@ def build_provider_list(
 
 @config_router.get("/prompt/sections/default", response_model=DefaultSectionsResponse)
 @limiter.limit(RATE_LIMIT_CONFIG, key_func=get_ip_only)
-async def get_default_sections(request: Request) -> DefaultSectionsResponse:
+async def get_default_sections(_request: Request) -> DefaultSectionsResponse:
     """Get default prompts for each section.
 
     Rate limited to prevent abuse, though this endpoint serves static data.
     """
-    _ = request  # Required for rate limiter but unused in handler
     return DefaultSectionsResponse(
         main=MAIN_PROMPT_DEFAULT,
         advanced=ADVANCED_PROMPT_DEFAULT,


### PR DESCRIPTION
### Motivation
- Remove a redundant no-op assignment and make the handler's unused request parameter explicit to reduce dead code and satisfy linters.

### Description
- Rename the `get_default_sections` handler parameter from `request` to `_request` and remove the `_ = request` no-op in `server/api/config_api.py` so the unused parameter is explicit without changing behavior.

### Testing
- Ran `cd server && uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`, and all server checks passed.
- Ran the app checks (`cd app && pnpm check`) earlier in this environment and the full check failed due to missing system GLib/GTK development libraries required by the Tauri/Rust build (this is an environment issue, not related to the code change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699028a6eac48333888c0610d3d211a7)