### PR TITLE
Docs: fix README inaccuracies in provider list and export description

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Open-source alternative to [Wispr Flow](https://wisprflow.ai), [Superwhisper](ht
 **Why not proprietary tools?** Unlike Wispr Flow or Superwhisper, this project gives you full control and transparency.
 
 **Fully customizable.** This is your voice interface, built your way:
-- **Choose your AI providers** — Pick your STT (Cartesia, Deepgram, AssemblyAI, Speechmatics, Azure, AWS, Google, Groq, OpenAI, Nemotron) and LLM (Cerebras, OpenAI, Anthropic, Gemini, Groq, OpenRouter), run fully local with Whisper and Ollama, or add more from [Pipecat's supported services](https://docs.pipecat.ai/server/services/supported-services)
+- **Choose your AI providers** — Pick your STT (Cartesia, Deepgram, AssemblyAI, Speechmatics, Azure, AWS, Google, Groq, OpenAI, Nemotron) and LLM (Cerebras, OpenAI, Anthropic, Gemini, Groq, OpenRouter, AWS Bedrock), run fully local with Whisper and Ollama, or add more from [Pipecat's supported services](https://docs.pipecat.ai/server/services/supported-services)
 - **Customize the formatting** — Modify prompts, add custom rules, build your personal dictionary
 - **Extend freely** — Built on [Pipecat](https://github.com/pipecat-ai/pipecat)'s modular pipeline, fully open-source
 
@@ -319,15 +319,15 @@ Tambourine supports exporting and importing your configuration data, making it e
 
 #### Export Data
 
-Go to **Settings > Data Management** and click the export button. Select a folder and Tambourine exports 5 files:
+Go to **Settings > Data Management** and click the export button. Select a folder and Tambourine exports the following files:
 
 | File                              | Description                                                |
 | --------------------------------- | ---------------------------------------------------------- |
 | `tambourine-settings.json`        | App settings (hotkeys, providers, audio preferences)       |
 | `tambourine-history.json`         | Transcription history entries                              |
-| `tambourine-prompt-main.md`       | Core formatting rules                                      |
-| `tambourine-prompt-advanced.md`   | Advanced features (backtrack corrections, list formatting) |
-| `tambourine-prompt-dictionary.md` | Personal dictionary for custom terminology                 |
+| `tambourine-prompt-main.md`       | Core formatting rules (included when prompt settings have been saved) |
+| `tambourine-prompt-advanced.md`   | Advanced features (included when prompt settings have been saved)     |
+| `tambourine-prompt-dictionary.md` | Personal dictionary (included when prompt settings have been saved)   |
 
 #### Import Data
 


### PR DESCRIPTION
## Summary

- Add **AWS Bedrock** to the LLM providers list — it is fully supported in code (`LLMProviderId.BEDROCK` in `server/protocol/providers.py`) and documented in `server/.env.example`, but was missing from the README feature description
- Clarify that prompt `.md` files are only included in exports when prompt settings have been saved (the previous wording \"exports 5 files\" was incorrect for fresh installs where `cleanup_prompt_sections` is `None`)

## Test plan

- [x] Verify AWS Bedrock appears in the providers list paragraph
- [ ] Verify the export table accurately describes conditional prompt file inclusion
